### PR TITLE
Gitignored VSC and Idea IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 .vscode/
 .idea/
-startup.iml
+*.iml
 
 # dependencies
 /node_modules


### PR DESCRIPTION
This commit contains the following changes:

- Modified `gitignore` to ignore `VS Code` and `IntelliJ` IDE configs