### PR TITLE
Fix for GET currentUser returns null

### DIFF
--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -69,10 +69,14 @@ export default class UserService {
       credentials: "include"
     }).then(response => {
       if (response.ok) {
-        return response.json();
+        return response;
       } else {
         throw new HttpError(response);
       }
+    }).then(response => { 
+      return response.json();
+    }).catch(error => { 
+      return {};
     });
   }
 


### PR DESCRIPTION
This pull request addresses the following issues:

When there is no current user, the currentUser API call returns null instead of an empty object. This commit adds a `catch` statement so that it will return an empty object gracefully. 

The backend API call has `User` object as return type and it might not easy to refactor the method to return a Response Object in a short period of time (and then it would be out of place with other methods returning `User` objects); thus the change is made in front end.  