### PR TITLE
Added Page 2 Service Category Tests, fixed page 2 mock

### DIFF
--- a/src/data/service-categories-page1.mock.json
+++ b/src/data/service-categories-page1.mock.json
@@ -1,25 +1,10 @@
 {
     "content": [
         {
-            "id": 3,
-            "popularity": 9,
+            "id": 10,
+            "popularity": 2,
             "icon": "img_url",
-            "serviceCategoryName": "Pets",
-            "services": [
-                {
-                    "id": 678,
-                    "serviceName": "Dog Groomers",
-                    "popularity": 10,
-                    "thumbnail": "https://picsum.photos/300/200",
-                    "questions": []
-                }
-            ]
-        },
-        {
-            "id": 4,
-            "popularity": 8,
-            "icon": "img_url",
-            "serviceCategoryName": "Wellness",
+            "serviceCategoryName": "Personal",
             "services": [
                 {
                     "id": 543,
@@ -31,55 +16,10 @@
             ]
         },
         {
-            "id": 5,
-            "popularity": 7,
+            "id": 11,
+            "popularity": 1,
             "icon": "img_url",
-            "serviceCategoryName": "Business",
-            "services": [
-                {
-                    "id": 567,
-                    "serviceName": "Makeup Artists",
-                    "popularity": 9,
-                    "thumbnail": "https://picsum.photos/300/200",
-                    "questions": []
-                }
-            ]
-        },
-        {
-            "id": 6,
-            "popularity": 6,
-            "icon": "img_url",
-            "serviceCategoryName": "Events",
-            "services": [
-                {
-                    "id": 234,
-                    "serviceName": "Exterior Painters",
-                    "popularity": 3,
-                    "thumbnail": "https://picsum.photos/300/200",
-                    "questions": []
-                }
-            ]
-        },
-        {
-            "id": 7,
-            "popularity": 5,
-            "icon": "img_url",
-            "serviceCategoryName": "Crafts",
-            "services": [
-                {
-                    "id": 345,
-                    "serviceName": "Handymen",
-                    "popularity": 5,
-                    "thumbnail": "https://picsum.photos/300/200",
-                    "questions": []
-                }
-            ]
-        },
-        {
-            "id": 8,
-            "popularity": 4,
-            "icon": "img_url",
-            "serviceCategoryName": "Design and Web",
+            "serviceCategoryName": "Photography",
             "services": [
                 {
                     "id": 456,
@@ -91,19 +31,11 @@
             ]
         },
         {
-            "id": 9,
-            "popularity": 3,
-            "icon": "img_url",
-            "serviceCategoryName": "Legal",
-            "services": [
-                {
-                    "id": 456,
-                    "serviceName": "Photographers",
-                    "popularity": 7,
-                    "thumbnail": "https://picsum.photos/300/200",
-                    "questions": []
-                }
-            ]
+            "id": 15,
+            "popularity": 300,
+            "icon": "",
+            "serviceCategoryName": "Test1",
+            "services": []
         }
     ],
     "pageable": {
@@ -113,22 +45,22 @@
             "empty": true
         },
         "pageSize": 7,
-        "pageNumber": 0,
-        "offset": 0,
+        "pageNumber": 1,
+        "offset": 7,
         "unpaged": false,
         "paged": true
     },
     "totalElements": 10,
-    "last": false,
+    "last": true,
     "totalPages": 2,
-    "first": true,
+    "first": false,
     "sort": {
         "sorted": false,
         "unsorted": true,
         "empty": true
     },
-    "numberOfElements": 7,
+    "numberOfElements": 3,
     "size": 7,
-    "number": 0,
+    "number": 1,
     "empty": false
 }

--- a/src/test/ServiceCategoryDOMPage2.test.js
+++ b/src/test/ServiceCategoryDOMPage2.test.js
@@ -1,32 +1,44 @@
 import "../services/ServiceCategoryService.mock"
 import { MemoryRouter } from "react-router-dom";
-import svccatmockdataZero from "../data/service-categories-page0.mock"
+import svccatmockdataOne from "../data/service-categories-page1.mock"
 import React from 'react'
 import renderer from 'react-test-renderer'
 import ServiceCategoryService from "../services/ServiceCategoryService"
 import ServiceCategoryTable from "../components/ServiceCategoryTable"
 const serviceCategoryService = ServiceCategoryService.getInstance();
 
-test("render correct # of entries (first page)", () => { 
+test("render correct # of entries (second page)", () => { 
     const component = renderer.create(
         <MemoryRouter>
             <ServiceCategoryTable
-                serviceCategories={svccatmockdataZero.content}
+                serviceCategories={svccatmockdataOne.content}
                 new_entry={{ serviceCategoryName: "", popularity: "", icon: "", id: -1 }}/>
         </MemoryRouter>
     );
     let root = component.root;
-    expect(root.findAllByType("tr").length).toBe(9);
+    expect(root.findAllByType("tr").length).toBe(3 + 2);
 })
 
 test("count buttons of the DOM, should be 7 lines + input line, 2 per line", () => { 
     const component = renderer.create(
         <MemoryRouter>
             <ServiceCategoryTable
-                serviceCategories={svccatmockdataZero.content}
+                serviceCategories={svccatmockdataOne.content}
                 new_entry={{ serviceCategoryName: "", popularity: "", icon: "", id: -1 }}/>
         </MemoryRouter>
     );
     let root = component.root;
-    expect(root.findAllByType("button").length).toBe((7+1)*2); 
+    expect(root.findAllByType("button").length).toBe((3+1)*2); 
+})
+
+test("count input text fields of the DOM, should be 2", () => { 
+    const component = renderer.create(
+        <MemoryRouter>
+            <ServiceCategoryTable
+                serviceCategories={svccatmockdataOne.content}
+                new_entry={{ serviceCategoryName: "", popularity: "", icon: "", id: -1 }}/>
+        </MemoryRouter>
+    );
+    let root = component.root;
+    expect(root.findAllByType("input").length).toBe(2); 
 })


### PR DESCRIPTION
This pull request contains the following changes:

- Added Service Category DOM tests for page 2 of the mock, while discovering that mock of page 2 is not as expected. Generated page 2 mock json again from production db (`pageNum=1&ipp=7`)